### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wxsub/element-plus-formkit/security/code-scanning/1](https://github.com/wxsub/element-plus-formkit/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves publishing to npm, it requires `contents: read` to access the repository contents and `packages: write` to publish the package. These permissions should be explicitly defined at the workflow level or the job level.

The `permissions` block will be added at the root of the workflow, applying to all jobs in the workflow. This ensures that the `GITHUB_TOKEN` has restricted permissions throughout the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
