### PR TITLE
Update formkit.vue

### DIFF
--- a/src/formkit.vue
+++ b/src/formkit.vue
@@ -277,7 +277,7 @@ defineExpose<FormKitExposed>({
   .el-row { row-gap: v-bind("`${props.rows?.rowGap || 5}px`") }
   .el-form-item { margin: 0; width: 100% }
   .el-form--label-top .el-form-item__label { padding: 0 }
-  .el-form-item__error { position: relative }
   .el-form-item--default { margin-bottom: 0 }
 }
 </style>
+


### PR DESCRIPTION
the Formkit stylesheet contains the incorrect declaration `.el-form-item__error { position: relative }` This should be corrected to `.el-form-item__error { position: absolute }`.