### PR TITLE
Add documentation for buckets method in expose.md

### DIFF
--- a/pages/docs/en/expose.md
+++ b/pages/docs/en/expose.md
@@ -94,6 +94,10 @@ import { type Instance } from 'element-plus-formkit';
 ```
 :::
 
+## buckets
+Retrieves all remote return result items with the `requester` property.
+
+**Return Value**: Array<{ key: string, value: any }>
 
 <script setup lang="ts">
 import formkit, { type Instance, setConfigure } from 'element-plus-formkit';

--- a/pages/docs/expose.md
+++ b/pages/docs/expose.md
@@ -92,6 +92,10 @@ import { type Instance } from 'element-plus-formkit';
 ```
 :::
 
+## buckets
+获取所有所有`requester`属性远程返回结果数据项。
+
+**返回值**: Array<{ key: string, value: any }>
 
 <script setup lang="ts">
 import formkit, { type Instance } from 'element-plus-formkit';


### PR DESCRIPTION
Added a new section describing the `buckets` method, including its purpose and return value, to both the English and Chinese documentation files.