### PR TITLE
Add styles for .search-box search input

### DIFF
--- a/pages/styles/theme-overrides.scss
+++ b/pages/styles/theme-overrides.scss
@@ -13,3 +13,8 @@
   text-decoration: underline;
   user-select: none;
 }
+
+.search-box input[type='search'] {
+  --search-input-width: 9rem;
+  padding: 0 1rem 0 2rem;
+}


### PR DESCRIPTION
Close the preceding CSS rule and add styles for .search-box input[type='search']: define --search-input-width as 9rem and adjust padding (0 1rem 0 2rem) to reserve space for the search icon.