### PR TITLE
Improve file type validation in uploader

### DIFF
--- a/src/utils/upload.class.ts
+++ b/src/utils/upload.class.ts
@@ -36,8 +36,18 @@ class FileUploader {
   }
 
   isValidFileType(file: File, typePatterns: string): boolean {
-    const Types = typePatterns.split(', ') || []
-    return Types.some((pattern: string) => (new RegExp(pattern)).test(file.type))
+    const types = typePatterns?.toLowerCase().match(/[^,\s]+/g)
+    if (!types?.length) return true
+
+    const fileName = file?.name?.toLowerCase() ?? ''
+    const fileType = file?.type?.toLowerCase() ?? ''
+
+    return types.some(pattern => {
+      if (pattern.startsWith('.')) return fileName.endsWith(pattern)
+      if (pattern.endsWith('/*')) return fileType.startsWith(pattern.slice(0, -2))
+      if (fileType === pattern) return true
+      try { return new RegExp(pattern, 'i').test(fileType) } catch { return false }
+    })
   }
 
   async action(file: File): Promise<void> {


### PR DESCRIPTION
Enhance FileUploader.isValidFileType to more robustly parse and match typePatterns. Patterns are split by commas/whitespace, and an empty set of patterns allows any file. Matching now supports file extension checks ('.ext'), wildcard MIME types ('type/*'), exact MIME matches, and regex patterns (case-insensitive) with safe try/catch handling. File name/type are normalized to lowercase and missing properties are handled gracefully.