### PR TITLE
Wrap append slot and pass modelValue

### DIFF
--- a/src/formkit.vue
+++ b/src/formkit.vue
@@ -47,7 +47,9 @@
               <p v-if="conf.hint" :class="$style['item-hint']" v-html="conf.hint"/>
             </el-form-item>
           </el-col>
-          <slot name="append" />
+          <el-col v-if="$slots.additional" :style="{ flex: 'none', width: 'auto' }">
+            <slot name="append" :value="modelValue" />
+          </el-col>
         </el-row>
       </el-form>
       <slot :config="configs" name="content" />


### PR DESCRIPTION
Replace the unconditional <slot name="append"/> with a conditional <el-col> wrapper that renders only when $slots.additional is present, applies { flex: 'none', width: 'auto' } styling, and forwards modelValue to the append slot as the value prop. This preserves layout and lets the append slot access the current model value.