### PR TITLE
Add autocomplete to async Modules mapping

### DIFF
--- a/src/asyncModulesLoader.ts
+++ b/src/asyncModulesLoader.ts
@@ -19,6 +19,7 @@ export const Modules: Record<string, Component> = {
   upload: defineAsyncComponent(() => import('./modules/upload.vue')),
   mention: defineAsyncComponent(() => import('./modules/mention.vue')),
   
+  autocomplete: asyncElementPlus('ElAutocomplete'),
   input: asyncElementPlus('ElInput'),
   inputTag: asyncElementPlus('ElInputTag'),
   selectV2: asyncElementPlus('ElSelectV2'),


### PR DESCRIPTION
Register the Element Plus Autocomplete component in the Modules map by adding `autocomplete: asyncElementPlus('ElAutocomplete')` to src/asyncModulesLoader.ts. This enables lazy-loading of the Autocomplete component and keeps input-related components consistent with the existing asyncElementPlus usage.