### PR TITLE
Bump version and rename slot to append

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "element-plus-formkit",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "dist/formkit.umd.js",
   "module": "dist/formkit.es.js",
   "types": "types/element-plus-formkit.d.ts",

--- a/src/formkit.vue
+++ b/src/formkit.vue
@@ -47,7 +47,7 @@
               <p v-if="conf.hint" :class="$style['item-hint']" v-html="conf.hint"/>
             </el-form-item>
           </el-col>
-          <el-col v-if="$slots.additional" :style="{ flex: 'none', width: 'auto' }">
+          <el-col v-if="$slots.append" :style="{ flex: 'none', width: 'auto' }">
             <slot name="append" :value="modelValue" />
           </el-col>
         </el-row>


### PR DESCRIPTION
Bump package version to 1.0.8 and update src/formkit.vue to use the 'append' slot instead of 'additional'. Change the v-if check to $slots.append and the slot name to 'append' so appended content renders correctly.