### PR TITLE
Add treeSelect module and update docs

### DIFF
--- a/pages/docs/en/modules.md
+++ b/pages/docs/en/modules.md
@@ -1188,82 +1188,91 @@ Output: {{ dataset.sliderValue || "-" }}
 
 A tree selector with dropdown menus, combining the functionality of the el-tree and el-select components.
 
+**Props-Specific Properties**
+
+| Name | Type | Description | Default
+| -------- | :----- | :----: | :----: |
+| valueKey | String | A key name that uniquely identifies the value; required when binding to an object type | id
+| labelKey | String | Specifies the label of an option as the value of a specific property of the option object | name
+
 <formkit
     :config="[
         {
             type: 'treeSelect',
-            label: 'Time Selection',
-            key: 'timeSelectValue',
+            label: 'Tree Selector',
+            key: 'treeSelectValue',
             props: {
                 'render-after-expand': false,
                 style: { width: '240px' },
-                data: [
-                    {
-                        value: '1',
-                        label: 'Level one 1',
-                        children: [
-                            {
-                                value: '1-1',
-                                label: 'Level two 1-1',
-                                children: [
-                                    {
-                                        value: '1-1-1',
-                                        label: 'Level three 1-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '2',
-                        label: 'Level one 2',
-                        children: [
-                            {
-                                value: '2-1',
-                                label: 'Level two 2-1',
-                                children: [
-                                    {
-                                        value: '2-1-1',
-                                        label: 'Level three 2-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '3',
-                        label: 'Level one 3',
-                        children: [
-                            {
-                                value: '3-1',
-                                label: 'Level two 3-1',
-                                children: [
-                                    {
-                                        value: '3-1-1',
-                                        label: 'Level three 3-1-1'
-                                    }
-                                ]
-                            },
-                            {
-                                value: '3-2',
-                                label: 'Level two 3-2',
-                                children: [
-                                    {
-                                        value: '3-2-1',
-                                        label: 'Level three 3-2-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            options: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]"
     v-model="dataset">
 </formkit>
 
-<p>Output: {{ dataset.timeSelectValue || "-" }}</p>
+<p>Output: {{ dataset.treeSelectValue || "-" }}</p>
 
 ```vue
 <formkit
@@ -1271,71 +1280,73 @@ A tree selector with dropdown menus, combining the functionality of the el-tree 
         {
             type: 'treeSelect',
             label: 'Time Selection',
-            key: 'timeSelectValue',
+            key: 'treeSelectValue',
             props: {
                 'render-after-expand': false,
                 style: { width: '240px' },
-                data: [
-                    {
-                        value: '1',
-                        label: 'Level one 1',
-                        children: [
-                            {
-                                value: '1-1',
-                                label: 'Level two 1-1',
-                                children: [
-                                    {
-                                        value: '1-1-1',
-                                        label: 'Level three 1-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '2',
-                        label: 'Level one 2',
-                        children: [
-                            {
-                                value: '2-1',
-                                label: 'Level two 2-1',
-                                children: [
-                                    {
-                                        value: '2-1-1',
-                                        label: 'Level three 2-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '3',
-                        label: 'Level one 3',
-                        children: [
-                            {
-                                value: '3-1',
-                                label: 'Level two 3-1',
-                                children: [
-                                    {
-                                        value: '3-1-1',
-                                        label: 'Level three 3-1-1'
-                                    }
-                                ]
-                            },
-                            {
-                                value: '3-2',
-                                label: 'Level two 3-2',
-                                children: [
-                                    {
-                                        value: '3-2-1',
-                                        label: 'Level three 3-2-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            options: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]"
     v-model="dataset">
@@ -1343,6 +1354,125 @@ A tree selector with dropdown menus, combining the functionality of the el-tree 
 
 <p>Output: {{ dataset.timeSelectValue || "-" }}</p>
 ```
+
+The `treeSelect` can also use the `requester` field to dynamically retrieve options.
+
+<formkit
+    :config="[
+        {
+            type: 'treeSelect',
+            label: 'Tree Selector',
+            key: 'treeSelectValue',
+            props: {
+                'render-after-expand': false,
+                style: { width: '240px' },
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            requester: fetchTreeSelectOptions,
+            handler: (response: any) => response?.items || []
+        }
+    ]"
+    v-model="dataset">
+</formkit>
+
+::: code-tabs
+@tab template
+```vue
+<formkit
+    :config="[
+        {
+            type: 'treeSelect',
+            label: 'Tree Selector',
+            key: 'treeSelectValue',
+            props: {
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            requester: fetchTreeSelectOptions,
+            handler: (response: any) => response?.items || []
+        }
+    ]"
+    v-model="dataset">
+</formkit>
+```
+@tab script
+```js
+import formkit from 'element-plus-formkit';
+
+const dataset = ref({})
+
+function fetchTreeSelectOptions() {
+    return new Promise((r, j) => {
+        setTimeout(() => {
+           r({
+            code: 200,
+            items: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+           })
+        }, 1000)
+    })
+}
+```
+:::
 
 ::: tip
 [Native ElTreeSelect API](https://element-plus.org/en-US/component/tree#attributes)Please write inside the props.
@@ -1432,4 +1562,74 @@ const options = ref([
     ]
   }
 ])
+
+function fetchTreeSelectOptions() {
+    return new Promise((r, j) => {
+        setTimeout(() => {
+           r({
+            code: 200,
+            items: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+           })
+        }, 1000)
+    })
+}
 </script>

--- a/pages/docs/modules.md
+++ b/pages/docs/modules.md
@@ -1194,6 +1194,13 @@ Output: {{ dataset.sliderValue || "-" }}
 
 含有下拉菜单的树形选择器，结合了 el-tree 和 el-select 两个组件的功能。
 
+**Props特有属性**
+
+| 名称 | 类型 | 说明 | 默认
+| -------- | :----- | :----: | :----: |
+| valueKey | String | 作为 value 唯一标识的键名，绑定值为对象类型时必填 | id
+| labelKey | String | 指定选项标签为选项对象的某个属性值 | name
+
 <formkit
     :config="[
         {
@@ -1203,73 +1210,75 @@ Output: {{ dataset.sliderValue || "-" }}
             props: {
                 'render-after-expand': false,
                 style: { width: '240px' },
-                data: [
-                    {
-                        value: '1',
-                        label: 'Level one 1',
-                        children: [
-                            {
-                                value: '1-1',
-                                label: 'Level two 1-1',
-                                children: [
-                                    {
-                                        value: '1-1-1',
-                                        label: 'Level three 1-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '2',
-                        label: 'Level one 2',
-                        children: [
-                            {
-                                value: '2-1',
-                                label: 'Level two 2-1',
-                                children: [
-                                    {
-                                        value: '2-1-1',
-                                        label: 'Level three 2-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '3',
-                        label: 'Level one 3',
-                        children: [
-                            {
-                                value: '3-1',
-                                label: 'Level two 3-1',
-                                children: [
-                                    {
-                                        value: '3-1-1',
-                                        label: 'Level three 3-1-1'
-                                    }
-                                ]
-                            },
-                            {
-                                value: '3-2',
-                                label: 'Level two 3-2',
-                                children: [
-                                    {
-                                        value: '3-2-1',
-                                        label: 'Level three 3-2-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            options: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]"
     v-model="dataset">
 </formkit>
 
-<p>Output: {{ dataset.timeSelectValue || "-" }}</p>
+<p>Output: {{ dataset.treeSelectValue || "-" }}</p>
 
 ```vue
 <formkit
@@ -1281,74 +1290,195 @@ Output: {{ dataset.sliderValue || "-" }}
             props: {
                 'render-after-expand': false,
                 style: { width: '240px' },
-                data: [
-                    {
-                        value: '1',
-                        label: 'Level one 1',
-                        children: [
-                            {
-                                value: '1-1',
-                                label: 'Level two 1-1',
-                                children: [
-                                    {
-                                        value: '1-1-1',
-                                        label: 'Level three 1-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '2',
-                        label: 'Level one 2',
-                        children: [
-                            {
-                                value: '2-1',
-                                label: 'Level two 2-1',
-                                children: [
-                                    {
-                                        value: '2-1-1',
-                                        label: 'Level three 2-1-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        value: '3',
-                        label: 'Level one 3',
-                        children: [
-                            {
-                                value: '3-1',
-                                label: 'Level two 3-1',
-                                children: [
-                                    {
-                                        value: '3-1-1',
-                                        label: 'Level three 3-1-1'
-                                    }
-                                ]
-                            },
-                            {
-                                value: '3-2',
-                                label: 'Level two 3-2',
-                                children: [
-                                    {
-                                        value: '3-2-1',
-                                        label: 'Level three 3-2-1'
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            options: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]"
     v-model="dataset">
 </formkit>
 
-<p>Output: {{ dataset.timeSelectValue || "-" }}</p>
+<p>Output: {{ dataset.treeSelectValue || "-" }}</p>
 ```
+
+treeSelect也可通过requester字段用于动态获取options
+
+<formkit
+    :config="[
+        {
+            type: 'treeSelect',
+            label: '树形选择器',
+            key: 'treeSelectValue',
+            props: {
+                'render-after-expand': false,
+                style: { width: '240px' },
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            requester: fetchTreeSelectOptions,
+            handler: (response: any) => response?.items || []
+        }
+    ]"
+    v-model="dataset">
+</formkit>
+
+::: code-tabs
+@tab template
+```vue
+<formkit
+    :config="[
+        {
+            type: 'treeSelect',
+            label: '树形选择器',
+            key: 'treeSelectValue',
+            props: {
+                labelKey: 'label',
+                valueKey: 'value'
+            },
+            requester: fetchTreeSelectOptions,
+            handler: (response: any) => response?.items || []
+        }
+    ]"
+    v-model="dataset">
+</formkit>
+```
+@tab script
+```js
+import formkit from 'element-plus-formkit';
+
+const dataset = ref({})
+
+function fetchTreeSelectOptions() {
+    return new Promise((r, j) => {
+        setTimeout(() => {
+           r({
+            code: 200,
+            items: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+           })
+        }, 1000)
+    })
+}
+```
+:::
 
 ::: tip
 [原生ElTreeSelect API](https://element-plus.org/zh-CN/component/tree#属性)请写入props内
@@ -1436,4 +1566,74 @@ const options = ref([
     ]
   }
 ])
+
+function fetchTreeSelectOptions() {
+    return new Promise((r, j) => {
+        setTimeout(() => {
+           r({
+            code: 200,
+            items: [
+                {
+                    value: '1',
+                    label: 'Level one 1',
+                    children: [
+                        {
+                            value: '1-1',
+                            label: 'Level two 1-1',
+                            children: [
+                                {
+                                    value: '1-1-1',
+                                    label: 'Level three 1-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '2',
+                    label: 'Level one 2',
+                    children: [
+                        {
+                            value: '2-1',
+                            label: 'Level two 2-1',
+                            children: [
+                                {
+                                    value: '2-1-1',
+                                    label: 'Level three 2-1-1'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    value: '3',
+                    label: 'Level one 3',
+                    children: [
+                        {
+                            value: '3-1',
+                            label: 'Level two 3-1',
+                            children: [
+                                {
+                                    value: '3-1-1',
+                                    label: 'Level three 3-1-1'
+                                }
+                            ]
+                        },
+                        {
+                            value: '3-2',
+                            label: 'Level two 3-2',
+                            children: [
+                                {
+                                    value: '3-2-1',
+                                    label: 'Level three 3-2-1'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+           })
+        }, 1000)
+    })
+}
 </script>

--- a/src/asyncModulesLoader.ts
+++ b/src/asyncModulesLoader.ts
@@ -18,6 +18,7 @@ export const Modules: Record<string, Component> = {
   inputNumber: defineAsyncComponent(() => import('./modules/inputNumber.vue')),
   upload: defineAsyncComponent(() => import('./modules/upload.vue')),
   mention: defineAsyncComponent(() => import('./modules/mention.vue')),
+  treeSelect: defineAsyncComponent(() => import('./modules/treeSelect.vue')),
   
   autocomplete: asyncElementPlus('ElAutocomplete'),
   input: asyncElementPlus('ElInput'),
@@ -29,8 +30,7 @@ export const Modules: Record<string, Component> = {
   cascader: asyncElementPlus('ElCascader'),
   rate: asyncElementPlus('ElRate'),
   switch: asyncElementPlus('ElSwitch'),
-  slider: asyncElementPlus('ElSlider'),
-  treeSelect: asyncElementPlus('ElTreeSelect')
+  slider: asyncElementPlus('ElSlider')
 };
 
 export default Object.keys(Modules);

--- a/src/modules/treeSelect.vue
+++ b/src/modules/treeSelect.vue
@@ -1,0 +1,45 @@
+<template>
+    <el-tree-select
+        v-model="_value"
+        :data="options"
+        :class="$style['formkit-module-treeSelect']"
+        :props="{ value: valueKey, label: labelKey }"
+        v-bind="$attrs">
+        <template
+            v-for="name in Object.keys($slots)"
+            #[name]="slotProps"
+            :key="`slot-${name}`">
+            <slot :name="name" v-bind="slotProps" />
+        </template>
+    </el-tree-select>
+</template>
+
+<script setup lang="ts">
+import { ElTreeSelect } from 'element-plus'
+
+const props = defineProps({
+    modelValue: { default: null },
+    options: { type: Array<any>, default: () => [] },
+    labelKey: { type: String, default: 'name' },
+    valueKey: { type: String, default: 'id' }
+})
+
+const emit = defineEmits(['update:modelValue']);
+
+const $attrs = useAttrs() as Record<string, any> & { labelKey?: string; };
+
+const _value: any = computed({
+    get: () => {
+        return props.modelValue ?? null;
+    },
+    set: (value) => {
+        emit('update:modelValue', value)
+    }
+})
+</script>
+
+<style module lang="scss">
+.formkit-module-treeSelect {
+    min-width: 50px;
+}
+</style>


### PR DESCRIPTION
Add a new treeSelect component (src/modules/treeSelect.vue) with v-model support, configurable labelKey/valueKey defaults, and scoped slot passthrough. Register the component in asyncModulesLoader (use local async component instead of element-plus proxy). Update English and Chinese docs (pages/docs/en/modules.md, pages/docs/modules.md) to replace inline data/props with an options array, introduce props-specific table (labelKey/valueKey), rename example dataset key to treeSelectValue, and add a requester/handler example for dynamic option loading.